### PR TITLE
Correct the cases in which to remove the old binaries

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -61,8 +61,8 @@ cd "$INSTALL_DIR"
 
 # clear old files
 echo "Clearing leftovers from basecli and basecoind."
-[[ ! -f "./basecli" ]] && rm "./basecli"
-[[ ! -f "./basecoind" ]] && rm "./basecoind"
+[[ -f "./basecli" ]] && rm "./basecli"
+[[ -f "./basecoind" ]] && rm "./basecoind"
 [[ -d "$HOME/.basecli" ]] && rm -r "$HOME/.basecli"
 [[ -d "$HOME/.basecoind" ]] && rm -r "$HOME/.basecoind"
 


### PR DESCRIPTION
I just discovered that I made a mistake in the condition which indicates whether to remove a file or not. This PR corrects it.
Previously the script checked whether a file **doesn't exist** and then tried to remove it; now it checks **if it exists** and then removes it.