### PR TITLE
Remove custom capitalization for architecture

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,9 +2,7 @@
 
 DEPENDENCIES="curl jq"
 
-KERNEL="$(uname -s)"
-MACHINE="$(uname -m)"
-ARCH="${KERNEL,,}_${MACHINE,,}" # lowercase(`uname -s`) + _ + lowercase(`uname -m`)
+ARCH="$(uname -s)_$(uname -m)"
 INSTALL_DIR="$HOME/galaxy"
 SEEDS=$(curl -s https://raw.githubusercontent.com/galaxypi/galaxy/develop/seeds)
 


### PR DESCRIPTION
This PR removes the custom capitalization for the system's architecture string.

This string previously got transformed to lowercase to avoid normalization issues with e.g. `Linux` and `linux`. It seems like it's not as much needed as I originally thought (from [a list of some `uname` outputs](https://en.wikipedia.org/wiki/Uname#Examples) it looks like they are all very consistently capitalized).

Since the Bash string operator I used (`${VAR,,}`) is only available in Bash 4 and above (and current macOS versions ship with the 9-year old Bash 3... :D), I think it's OK to drop this capitalization.
It would be totally possible to replace this with a not-built-in way (e.g. `tr`), but as it's not as needed as I originally thought I think it's OK to simply drop it.

Please note that this changes the semantic of how release assets are named, and if this should get merged it's **needed to rename the assets** accordingly.