### PR TITLE
Add set -e at top to stop on errors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 DEPENDENCIES="curl jq"
 


### PR DESCRIPTION
Bash scripts are basically a set of commands which get executed line by line. If one command fails, it often means that an assumption didn't work as expected (e.g. in https://github.com/galaxypi/galaxy/pull/29#issuecomment-408716011 the case).

With `set -e` Bash stops the execution on the first non-true return value.