### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 Galaxy's mission is to become the world's largest network of decentralized nodes offering services for decentralized networks.  We are focused on scaling a currency across the network, launching an SDK for developers to create apps and other nodes that run acorss the network and tightly integrating our nodes with mobile phones in particular.  We think smartphones make for poor nodes but they servce as ideal platforms to control and monitor nodes.
 
-Galaxy is comprised of a currency which can be earned for compute tasks across the network and developer tools like a command line interface and a software development kit are in the pipeline which will allow developers to create third party apps and extend the capabilitities of the network.
+Galaxy is comprised of a currency which can be earned for compute tasks across the network and developer tools like a command line interface and a software development kit are in the pipeline which will allow developers to create third party apps and extend the capabilities of the network.
 
 Relatively speaking very few people actually run nodes for a number of reasons.  First of all most users own a laptop and a smartphone, both of which make for poor nodes as they are not designed to be always working, always connected and dedicated to a specific task.  Nodes are not easy to setup even for experienced developers.  Configuring a node can be very time intensive and often is unsupported with little to no documentation.  Our goal is to provide a platform for developers to easily create new nodes and a marketplace where end users can easily run nodes and participate in those networks.
 


### PR DESCRIPTION
This PR fixes a small typo in the readme: `capabilitities` -> `capabilities`.